### PR TITLE
フロントエンド総合課題2 掲示板API課題 課題2

### DIFF
--- a/js/bbs-api/api_client.js
+++ b/js/bbs-api/api_client.js
@@ -1,5 +1,5 @@
 'use strict'
-const host = 'http://52.198.64.33:20780'
+const host = 'http://35.72.4.134:20780'
 const registerHost = host + '/register'
 const loginHost = host + '/login'
 const logoutHost = host + '/logout'
@@ -12,7 +12,7 @@ const getToken = () => {
     return param
 }
 
-const executeApi = async (request, params, btn) => {
+const executeApi = async (request, params, pressedButtonId) => {
     await fetch(request, params)
     .then((response) => {
         if (!response.ok) {
@@ -23,7 +23,7 @@ const executeApi = async (request, params, btn) => {
     })
     
     .then(data => {
-        setMessage(data, btn)
+        setMessage(data, pressedButtonId)
         if (!data["token"]) {
             if (!data["status"]) {
                 if (!data["message"]) {
@@ -44,7 +44,7 @@ const executeApi = async (request, params, btn) => {
 }
 
 const registerUser = async (name, bio, password) => {
-    const btn = 'registerSubmit'
+    const pressedButtonId = 'registerSubmit'
     const bodyParams = {
         'name': name,
         'bio': bio,
@@ -57,11 +57,11 @@ const registerUser = async (name, bio, password) => {
         },
         body: JSON.stringify(bodyParams)
     }
-    await executeApi(registerHost, params, btn)
+    await executeApi(registerHost, params, pressedButtonId)
 }
 
 const loginUser = async (name, password) => {
-    const btn = 'loginSubmit'
+    const pressedButtonId = 'loginSubmit'
     const bodyParams = {
         'name': name,
         'password': password
@@ -73,11 +73,11 @@ const loginUser = async (name, password) => {
         },
         body: JSON.stringify(bodyParams)
     }
-    executeApi(loginHost, params, btn)
+    executeApi(loginHost, params, pressedButtonId)
 }
 
 const logoutUser = async () => {
-    const btn = 'logoutSubmit'
+    const pressedButtonId = 'logoutSubmit'
     const token = getToken()
     const params = {
         method: 'post',
@@ -86,11 +86,11 @@ const logoutUser = async () => {
             'Authorization': token
         }
     }
-    await executeApi(logoutHost, params, btn)
+    await executeApi(logoutHost, params, pressedButtonId)
 }
 
 const getUser = async (id) => {
-    const btn = 'usersIdGetSubmit'
+    const pressedButtonId = 'usersIdGetSubmit'
     const token = getToken()
     const url = new URL(usersHost)
     const request = new Request(url + '/' + id)
@@ -101,11 +101,11 @@ const getUser = async (id) => {
             'Authorization': token
         }
     }
-    await executeApi(request, params, btn)
+    await executeApi(request, params, pressedButtonId)
 }
 
 const getUsers = async (perPage, page, q) => {
-    const btn = 'usersGetSubmit'
+    const pressedButtonId = 'usersGetSubmit'
     const token = getToken()
     const url = new URL(usersHost)
     const queryParams = new URLSearchParams({
@@ -121,11 +121,11 @@ const getUsers = async (perPage, page, q) => {
             'Authorization': token
         }
     }
-    await executeApi(request, params, btn)
+    await executeApi(request, params, pressedButtonId)
 }
 
 const deleteUser = async () => {
-    const btn = 'usersDeleteSubmit'
+    const pressedButtonId = 'usersDeleteSubmit'
     const token = getToken()
     const params = {
         method: 'delete',
@@ -134,11 +134,11 @@ const deleteUser = async () => {
             'Authorization': token
         }
     }
-    await executeApi(usersHost, params, btn)
+    await executeApi(usersHost, params, pressedButtonId)
 }
 
 const editBioUser = async (bio) => {
-    const btn = 'usersEditSubmit'
+    const pressedButtonId = 'usersEditSubmit'
     const token = getToken()
     const bodyParam = {
         'bio': bio
@@ -151,11 +151,11 @@ const editBioUser = async (bio) => {
         },
         body: JSON.stringify(bodyParam)
     }
-    await executeApi(usersHost, params, btn)
+    await executeApi(usersHost, params, pressedButtonId)
 }
 
 const newThread = async (title) => {
-    const btn = 'threadsPostSubmit'
+    const pressedButtonId = 'threadsPostSubmit'
     const token = getToken()
     const bodyParams = {
         'title': title
@@ -168,11 +168,11 @@ const newThread = async (title) => {
         },
         body: JSON.stringify(bodyParams)
     }
-    executeApi(threadsHost, params, btn)
+    executeApi(threadsHost, params, pressedButtonId)
 }
 
 const getThreads = async (perPage, page, q) => {
-    const btn = 'threadsGetSubmit'
+    const pressedButtonId = 'threadsGetSubmit'
     const token = getToken()
     const url = new URL(threadsHost)
     const queryParams = new URLSearchParams({
@@ -188,11 +188,11 @@ const getThreads = async (perPage, page, q) => {
             'Authorization': token
         }
     }
-    await executeApi(request, params, btn)
+    await executeApi(request, params, pressedButtonId)
 }
 
 const getThread = async (id) => {
-    const btn = 'threadGetSubmit'
+    const pressedButtonId = 'threadGetSubmit'
     const token = getToken()
     const url = new URL(threadsHost)
     const request = new Request(url + '/' + id)
@@ -203,11 +203,11 @@ const getThread = async (id) => {
             'Authorization': token
         }
     }
-    await executeApi(request, params, btn)
+    await executeApi(request, params, pressedButtonId)
 }
 
 const editThread = async (id, title) => {
-    const btn = 'threadEditSubmit'
+    const pressedButtonId = 'threadEditSubmit'
     const token = getToken()
     const url = new URL(threadsHost)
     const request = new Request(url + '/' + id)
@@ -222,5 +222,5 @@ const editThread = async (id, title) => {
         },
         body: JSON.stringify(bodyParam)
     }
-    await executeApi(request, params, btn)
+    await executeApi(request, params, pressedButtonId)
 }

--- a/js/bbs-api/api_client.js
+++ b/js/bbs-api/api_client.js
@@ -4,6 +4,7 @@ const registerHost = host + '/register'
 const loginHost = host + '/login'
 const logoutHost = host + '/logout'
 const usersHost = host + '/users'
+const threadsHost = host + '/threads'
 
 const getToken = () => {
     const token = localStorage.getItem("token")
@@ -151,4 +152,75 @@ const editBioUser = async (bio) => {
         body: JSON.stringify(bodyParam)
     }
     await executeApi(usersHost, params, btn)
+}
+
+const newThread = async (title) => {
+    const btn = 'threadsPostSubmit'
+    const token = getToken()
+    const bodyParams = {
+        'title': title
+    }
+    const params = {
+        method: 'post',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': token
+        },
+        body: JSON.stringify(bodyParams)
+    }
+    executeApi(threadsHost, params, btn)
+}
+
+const getThreads = async (perPage, page, q) => {
+    const btn = 'threadsGetSubmit'
+    const token = getToken()
+    const url = new URL(threadsHost)
+    const queryParams = new URLSearchParams({
+        'per_page': perPage,
+        'page': page,
+        'q': q
+    })
+    const request = new Request(url + '?' + queryParams)
+    const params = {
+        method: 'get',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': token
+        }
+    }
+    await executeApi(request, params, btn)
+}
+
+const getThread = async (id) => {
+    const btn = 'threadGetSubmit'
+    const token = getToken()
+    const url = new URL(threadsHost)
+    const request = new Request(url + '/' + id)
+    const params = {
+        method: 'get',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': token
+        }
+    }
+    await executeApi(request, params, btn)
+}
+
+const editThread = async (id, title) => {
+    const btn = 'threadEditSubmit'
+    const token = getToken()
+    const url = new URL(threadsHost)
+    const request = new Request(url + '/' + id)
+    const bodyParam = {
+        'title': title
+    }
+    const params = {
+        method: 'patch',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': token
+        },
+        body: JSON.stringify(bodyParam)
+    }
+    await executeApi(request, params, btn)
 }

--- a/js/bbs-api/index.html
+++ b/js/bbs-api/index.html
@@ -52,13 +52,24 @@
         <td><button id="threadsGetSubmit">送信</button></td>
       </tr>
       <tr>
-        <td>threadsPost</td>
+        <td>threadPost</td>
         <td><input type="text" id="threadsPostTitle" placeholder="title" /></td>
         <td><button id="threadsPostSubmit">送信</button></td>
       </tr>
       <tr>
+        <td>threadGet</td>
+        <td><input type="number" id="threadGet" placeholder="id" /></td>
+        <td><button id="threadGetSubmit">送信</button></td>
+      </tr>
+      <tr>
+        <td>threadEdit</td>
+        <td><input type="number" id="threadEditId" placeholder="id" /></td>
+        <td><input type="text" id="threadEdit" placeholder="title" /></td>
+        <td><button id="threadEditSubmit">送信</button></td>
+      </tr>
+      <tr>
         <td>repliesGet</td>
-        <td><input type="number" id="repliesGetThreadId" placeholder="threadId" /></td>
+        <td><input type="number" id="threadGet" placeholder="threadId" /></td>
         <td><button id="repliesGetSubmit">送信</button></td>
       </tr>
       <tr>

--- a/js/bbs-api/index.html
+++ b/js/bbs-api/index.html
@@ -69,7 +69,7 @@
       </tr>
       <tr>
         <td>repliesGet</td>
-        <td><input type="number" id="threadGet" placeholder="threadId" /></td>
+        <td><input type="number" id="repliesGetThreadId" placeholder="threadId" /></td>
         <td><button id="repliesGetSubmit">送信</button></td>
       </tr>
       <tr>

--- a/js/bbs-api/main.js
+++ b/js/bbs-api/main.js
@@ -57,6 +57,37 @@ usersEditSubmit.addEventListener('click', () => {
     editBioUser(bio)
 })
 
+const threadsPostSubmit = document.getElementById("threadsPostSubmit")
+threadsPostSubmit.addEventListener('click', () => {
+    const title = document.getElementById("threadsPostTitle").value
+    setElementReset()
+    newThread(title)
+})
+
+const threadsGetSubmit = document.getElementById("threadsGetSubmit")
+threadsGetSubmit.addEventListener('click', () => {
+    const perPage = document.getElementById("threadsGetPerPage").value
+    const page = document.getElementById("threadsGetPage").value
+    const q = document.getElementById("threadsGetQ").value
+    setElementReset()
+    getThreads(perPage, page, q)
+})
+
+const threadGetSubmit = document.getElementById("threadGetSubmit")
+threadGetSubmit.addEventListener('click', () => {
+    const id = document.getElementById("threadGet").value
+    setElementReset()
+    getThread(id)
+})
+
+const threadEditSubmit = document.getElementById("threadEditSubmit")
+threadEditSubmit.addEventListener('click', () => {
+    const id = document.getElementById("threadEditId").value
+    const title = document.getElementById("threadEdit").value
+    setElementReset()
+    editThread(id, title)
+})
+
 const setErrorMessage = (message) => {
     elementMessage.innerHTML = 'メッセージ'
     elementErrorMessage.innerHTML = message
@@ -114,6 +145,42 @@ const setMessage = (data, btn) => {
         elementMessage.innerHTML = 'メッセージ'
         if (!data["message"]) {
             elementMessageContent.innerHTML = 'bioを書き換えました。'
+        }
+        if (data["message"] === 'Unauthenticated.') {
+            elementMessageContent.innerHTML = 'ログインしてください。'
+        }
+    }
+    if (btn === 'threadsPostSubmit') {
+        elementMessage.innerHTML = 'メッセージ'
+        if (!data["message"]) {
+            elementMessageContent.innerHTML = 'スレッドを作成しました。'
+        }
+        if (data["message"] === 'Unauthenticated.') {
+            elementMessageContent.innerHTML = 'ログインしてください。'
+        }
+    }
+    if (btn === 'threadGetSubmit') {
+        elementMessage.innerHTML = 'メッセージ'
+        if (!data["message"]) {
+            elementMessageContent.innerHTML = 'スレッドを取得しました。'
+        }
+        if (data["message"] === 'Unauthenticated.') {
+            elementMessageContent.innerHTML = 'ログインしてください。'
+        }
+    }
+    if (btn === 'threadEditSubmit') {
+        elementMessage.innerHTML = 'メッセージ'
+        if (!data["message"]) {
+            elementMessageContent.innerHTML = 'スレッドを編集しました。'
+        }
+        if (data["message"] === 'Unauthenticated.') {
+            elementMessageContent.innerHTML = 'ログインしてください。'
+        }
+    }
+    if (btn === 'threadsGetSubmit') {
+        elementMessage.innerHTML = 'メッセージ'
+        if (!data["message"]) {
+            elementMessageContent.innerHTML = 'スレッド一覧を取得しました。'
         }
         if (data["message"] === 'Unauthenticated.') {
             elementMessageContent.innerHTML = 'ログインしてください。'

--- a/js/bbs-api/main.js
+++ b/js/bbs-api/main.js
@@ -93,22 +93,22 @@ const setErrorMessage = (message) => {
     elementErrorMessage.innerHTML = message
 }
 
-const setMessage = (data, btn) => {
-    if (btn === 'registerSubmit') {
+const setMessage = (data, pressedButtonId) => {
+    if (pressedButtonId === 'registerSubmit') {
         elementMessage.innerHTML = 'メッセージ'
         elementMessageContent.innerHTML = '新規登録に成功しました。'
         if (data["message"]) {
             elementMessageContent.innerHTML = data["message"]
         }
     }
-    if (btn === 'loginSubmit') {
+    if (pressedButtonId === 'loginSubmit') {
         elementMessage.innerHTML = 'メッセージ'
         elementMessageContent.innerHTML = 'ログインに成功しました。'
         if (data["message"]) {
             elementMessageContent.innerHTML = data["message"]
         }
     }
-    if (btn === 'logoutSubmit') {
+    if (pressedButtonId === 'logoutSubmit') {
         elementMessage.innerHTML = 'メッセージ'
         elementMessageContent.innerHTML = 'ログアウトに成功しました。'
         if (data["message"]) {
@@ -119,19 +119,19 @@ const setMessage = (data, btn) => {
             elementMessageContent.innerHTML = 'ログインしてください。'
         }
     }
-    if (btn === 'usersIdGetSubmit') {
+    if (pressedButtonId === 'usersIdGetSubmit') {
         if (!data["data"] && data["message"] === 'Unauthenticated.') {
             elementMessage.innerHTML = 'メッセージ'
             elementMessageContent.innerHTML = 'ログインしてください。'
         }
     }
-    if (btn === 'usersGetSubmit') {
+    if (pressedButtonId === 'usersGetSubmit') {
         if (!data["data"] && data["message"] === 'Unauthenticated.') {
             elementMessage.innerHTML = 'メッセージ'
             elementMessageContent.innerHTML = 'ログインしてください。'
         }
     }
-    if (btn === 'usersDeleteSubmit') {
+    if (pressedButtonId === 'usersDeleteSubmit') {
         if (data["message"]) {
             elementMessage.innerHTML = 'メッセージ'
             elementMessageContent.innerHTML = data["message"]
@@ -141,7 +141,7 @@ const setMessage = (data, btn) => {
             elementMessageContent.innerHTML = 'ログインしてください。'
         }
     }
-    if (btn === 'usersEditSubmit') {
+    if (pressedButtonId === 'usersEditSubmit') {
         elementMessage.innerHTML = 'メッセージ'
         if (!data["message"]) {
             elementMessageContent.innerHTML = 'bioを書き換えました。'
@@ -150,7 +150,7 @@ const setMessage = (data, btn) => {
             elementMessageContent.innerHTML = 'ログインしてください。'
         }
     }
-    if (btn === 'threadsPostSubmit') {
+    if (pressedButtonId === 'threadsPostSubmit') {
         elementMessage.innerHTML = 'メッセージ'
         if (!data["message"]) {
             elementMessageContent.innerHTML = 'スレッドを作成しました。'
@@ -159,7 +159,7 @@ const setMessage = (data, btn) => {
             elementMessageContent.innerHTML = 'ログインしてください。'
         }
     }
-    if (btn === 'threadGetSubmit') {
+    if (pressedButtonId === 'threadGetSubmit') {
         elementMessage.innerHTML = 'メッセージ'
         if (!data["message"]) {
             elementMessageContent.innerHTML = 'スレッドを取得しました。'
@@ -168,7 +168,7 @@ const setMessage = (data, btn) => {
             elementMessageContent.innerHTML = 'ログインしてください。'
         }
     }
-    if (btn === 'threadEditSubmit') {
+    if (pressedButtonId === 'threadEditSubmit') {
         elementMessage.innerHTML = 'メッセージ'
         if (!data["message"]) {
             elementMessageContent.innerHTML = 'スレッドを編集しました。'
@@ -177,7 +177,7 @@ const setMessage = (data, btn) => {
             elementMessageContent.innerHTML = 'ログインしてください。'
         }
     }
-    if (btn === 'threadsGetSubmit') {
+    if (pressedButtonId === 'threadsGetSubmit') {
         elementMessage.innerHTML = 'メッセージ'
         if (!data["message"]) {
             elementMessageContent.innerHTML = 'スレッド一覧を取得しました。'


### PR DESCRIPTION
# 実装要件
###  `/threads` APIを呼び出し、投稿機能を作成
    - スレッドを作成して投稿、スレッド一覧の取得、指定のスレッドを取得、自分の投稿したスレッドの編集をそれぞれ実装

# 実装内容

## threadEdit スレッド編集機能の実装
編集したい投稿idと内容をtitleへ入力すると、メッセージと取得内容をHTMLとconsoleへ出力する。
未ログイン状態で実行するとエラーになり再ログインを促すメッセージを表示する。
<img width="1204" alt="image" src="https://user-images.githubusercontent.com/63387780/174300082-e37f5915-7c34-4206-9649-653c1cbfdca3.png">

## threadsGet スレッド一覧取得機能の実装
qへ入力されたキーワードからあいまい検索され該当のスレッドを取得する。
メッセージと取得内容をHTMLとconsoleへ出力する。
未ログイン状態で実行するとエラーになり再ログインを促すメッセージを表示する。
<img width="1095" alt="image" src="https://user-images.githubusercontent.com/63387780/174301087-b698812c-d876-4fe2-82f7-2bccdcbad4e4.png">

## threadPost スレッド新規投稿機能の実装
titleに入力されたキーワードから新規スレッドを投稿する。
メッセージと取得内容をHTMLとconsoleへ出力する。
未ログイン状態で実行するとエラーになり再ログインを促すメッセージを表示する。
<img width="1102" alt="image" src="https://user-images.githubusercontent.com/63387780/174302256-ccd44332-6219-4dcd-908e-a32f71576da2.png">

## threadGet スレッド取得機能の実装
入力されたidに該当する投稿を取得する。
メッセージと取得内容をHTMLとconsoleへ出力する。
未ログイン状態で実行するとエラーになり再ログインを促すメッセージを表示する。
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/63387780/174303019-7ab6a270-91f2-4de8-93c7-93750dbce878.png">
